### PR TITLE
Add test for rule without filters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,7 @@ Failures:
     - 'modifyHeaders can add a Sec-GPC header': "Invalid call to declarativeNetRequest.updateDynamicRules(). Error with rule at index 0: Rule with id 5 is invalid. `modifyHeaders` is not a supported action type". `modifyHeaders` is not supported.
     - 'initiatorDomains' condition limits matches to requests initiated by matching domain: This option is only supported under the legacy 'domains' property.
     - 'domains' condition list matches initators' subdomains: Safari only matches exact domains in `domains` conditions.
-
+    - The rule condition must contain `regexFilter` or `urlFilter`, otherwise the rule is ignored for dynamic rules and it breaks setting static rulesets.
 ### Safari Technology Preview 165
 
 Failures:
@@ -80,6 +80,7 @@ Failures:
     - 'modifyHeaders can add a Sec-GPC header'. Same as in 16.3.
     - ''initiatorDomains' condition limits matches to requests initiated by matching domain'. Same as in 16.3.
     - ''domains' condition list matches initators' subdomains'. Same as in 16.3
+    - The rule condition must contain `regexFilter` or `urlFilter`, otherwise the rule is ignored for dynamic rules and it breaks setting static rulesets.
 
 ### Firefox Nightly 112
 

--- a/Shared (Extension)/Resources/tests/test.declarativeNetRequest.js
+++ b/Shared (Extension)/Resources/tests/test.declarativeNetRequest.js
@@ -768,4 +768,26 @@ describe("chrome.declarativeNetRequest", () => {
     );
     expect(result.find((r) => r.id === "script").status).to.equal("loaded");
   });
+
+  it('adds dynamic block rule without regexFilter and urlFiler in condition', async () => {
+    await dnrTest(
+      [
+        {
+          id: 1,
+          priority: 1,
+          action: {
+            type: "block",
+          },
+          condition: {
+            domainType: 'thirdParty',
+            domains: ['example.com'],
+          },
+        },
+      ],
+      async () => {
+        const rules = await chrome.declarativeNetRequest.getDynamicRules();
+        expect(rules.length).to.equal(1);
+      }
+    );
+  });
 });


### PR DESCRIPTION
I found yet another bug in Safari DNR implementation. Rules without `regexFilter` or `urlFilter` are ignored in dynamic rules, and what's worse - they break switching on/off static rules.

Here you have added a test for it. I have checked, and on Chrome 112 all tests still pass, but on Safari 16.4 and Safari TP 167 added test fails.