### PR TITLE
Tests for web accessible resources issues

### DIFF
--- a/Shared (Extension)/Resources/tests/index.js
+++ b/Shared (Extension)/Resources/tests/index.js
@@ -3,5 +3,6 @@ import './test.chrome.js'
 import './test.contentScripts.js'
 import './test.scripting.js'
 import './test.declarativeNetRequest.js'
+import './test.webAccessibleResources.js'
 
 mocha.run();

--- a/Shared (Extension)/Resources/tests/test.webAccessibleResources.js
+++ b/Shared (Extension)/Resources/tests/test.webAccessibleResources.js
@@ -1,0 +1,62 @@
+import { loadPageAndWaitForLoad } from "./utils.js";
+const { expect } = chai;
+
+describe("web_accessible_resources", () => {
+  it("script can be loaded by a webpage", async () => {
+    const tab = await loadPageAndWaitForLoad(
+      "https://privacy-test-pages.glitch.me/"
+    );
+    // inject the script tag
+    await chrome.scripting.executeScript({
+      target: {
+        tabId: tab.id,
+      },
+      world: "ISOLATED",
+      func: () => {
+        const script = document.createElement("script");
+        script.src = chrome.runtime.getURL("/surrogate.js");
+        (document.head || document.documentElement).appendChild(script);
+      },
+    });
+    await new Promise(resolve => setTimeout(resolve, 10))
+    // read script value out from main world
+    const result = await chrome.scripting.executeScript({
+      target: {
+        tabId: tab.id,
+      },
+      world: "MAIN",
+      func: () => window.surrogate_test,
+    });
+    // chrome.tabs.remove(tab.id);
+    expect(result[0].result).to.equal("success");
+  });
+
+  it("script cannot be loaded by a webpage not declared in manifest", async () => {
+    const tab = await loadPageAndWaitForLoad(
+      "https://example.com/"
+    );
+    // inject the script tag
+    await chrome.scripting.executeScript({
+      target: {
+        tabId: tab.id,
+      },
+      world: "ISOLATED",
+      func: () => {
+        const script = document.createElement("script");
+        script.src = chrome.runtime.getURL("/surrogate.js");
+        (document.head || document.documentElement).appendChild(script);
+      },
+    });
+    await new Promise(resolve => setTimeout(resolve, 10))
+    // read script value out from main world
+    const result = await chrome.scripting.executeScript({
+      target: {
+        tabId: tab.id,
+      },
+      world: "MAIN",
+      func: () => window.surrogate_test,
+    });
+    await chrome.tabs.remove(tab.id);
+    expect(result[0].result).to.equal(null);
+  });
+});


### PR DESCRIPTION
New tests for `web_accessible_resources` manifest entry.
- Demonstrates a simple pattern of declaring a web_accessible_resource and injecting it in a page via content-script.
- This fails in Safari with an error "You do not have permission to access the requested resource.". This suggests that the `web_accessible_resources` manifest entry is being ignored.